### PR TITLE
updating page title for the bucket

### DIFF
--- a/wp-content/themes/aspen/functions.php
+++ b/wp-content/themes/aspen/functions.php
@@ -46,7 +46,7 @@ function aspen_stylesheet() {
 add_action( 'wp_enqueue_scripts', 'aspen_stylesheet', 20 );
 
 function aspen_archive_rounduplink_title() {
-	$title = __( 'The Bucket: News of Interest to Aspenites', 'aspen' );
+	$title = __( 'The Bucket', 'aspen' );
 	return $title;
 }
 add_filter( 'largo_archive_rounduplink_title', 'aspen_archive_rounduplink_title' );


### PR DESCRIPTION
Per request in Help Scout 1932, I've updated the page title by removing "news of interest to Aspenites".

@tylermachado please review and deploy to staging. If looks good to you on staging it can go to production immediately. Thanks!