### PR TITLE
Custom daily roundup RSS feed

### DIFF
--- a/wp-content/themes/aspen/feed-daily-roundup.php
+++ b/wp-content/themes/aspen/feed-daily-roundup.php
@@ -17,18 +17,18 @@ function rss_date( $timestamp = null ) {
 }
 
 /**
- * Function to see if we want to grab posts from today after 12PM
- * or from yesterday after 12PM until today before 12PM
+ * Function to see if we want to grab posts from today after 12:30PM
+ * or from yesterday after 12PM until today before 12:30PM
  * 
  * @return Arr $query_time An array of arguments to use in the query_posts date_query arg.
  */
 function rss_posts_date_query() {
 
-    if( current_time( 'H' ) < 12 ) {
+    if( current_time( 'H:m' ) < '12:30' ) {
 
         $query_time = array(
             array(
-                'before' => date( 'm/d/Y 12:00:00' ),
+                'before' => date( 'm/d/Y 12:30:00' ),
                 'after' => date( 'm/d/Y 12:00:00', strtotime( '-1 days' ) ),
                 'inclusive' => false,
             )
@@ -38,7 +38,7 @@ function rss_posts_date_query() {
 
         $query_time = array(
             array(
-                'after' => date( 'm/d/Y 12:00:00' ),
+                'after' => date( 'm/d/Y 12:30:00' ),
                 'inclusive' => true,
             )
         );

--- a/wp-content/themes/aspen/feed-daily-roundup.php
+++ b/wp-content/themes/aspen/feed-daily-roundup.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Template Name: Daily Roundup Feed
+ * Copied from https://raw.githubusercontent.com/pastpages/Largo/master/feed-mailchimp.php
+ * A feed with thumbnail images for MailChimp import that pulls in all saved links from 12PM to the following day 12PM
+ * Feed address to use for MailChimp import will be http://myurl.com/?feed=daily-roundup
+ *
+ * @package Largo
+ * @since 0.2
+ */
+
+$numposts = -1;
+
+function rss_date( $timestamp = null ) {
+  $timestamp = ($timestamp==null) ? time() : $timestamp;
+  echo date(DATE_RSS, $timestamp);
+}
+
+/**
+ * Function to see if we want to grab posts from today after 12PM
+ * or from yesterday after 12PM until today before 12PM
+ * 
+ * @return Arr $query_time An array of arguments to use in the query_posts date_query arg.
+ */
+function rss_posts_date_query() {
+
+    if( current_time( 'H' ) < 12 ) {
+
+        $query_time = array(
+            array(
+                'before' => date( 'm/d/Y 12:00:00' ),
+                'after' => date( 'm/d/Y 12:00:00', strtotime( '-1 days' ) ),
+                'inclusive' => false,
+            )
+        );
+
+    } else {
+
+        $query_time = array(
+            array(
+                'after' => date( 'm/d/Y 12:00:00' ),
+                'inclusive' => true,
+            )
+        );
+
+    }
+
+    return $query_time;
+
+}
+
+$posts = query_posts( array(
+  'showposts' => $numposts,
+  'post_type' => 'rounduplink',
+  'date_query' => rss_posts_date_query(),
+) );
+
+$lastpost = $numposts - 1;
+
+header("Content-Type: application/rss+xml; charset=UTF-8");
+echo '<?xml version="1.0" encoding="UTF-8"?>';
+?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:media="http://search.yahoo.com/mrss/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<channel>
+  <title><?php bloginfo_rss('name'); ?></title>
+  <link><?php bloginfo_rss('url'); ?></link>
+  <description><?php bloginfo_rss('description'); ?></description>
+  <language><?php bloginfo('language'); ?></language>
+  <pubDate><?php rss_date( strtotime($ps[$lastpost]->post_date_gmt) ); ?></pubDate>
+  <lastBuildDate><?php rss_date( strtotime($ps[$lastpost]->post_date_gmt) ); ?></lastBuildDate>
+  <managingEditor><?php bloginfo_rss('admin_email'); ?></managingEditor>
+
+<?php foreach ($posts as $post) { ?>
+  <item>
+    <title><?php the_title_rss(); ?></title>
+    <link><?php the_permalink(); ?></link>
+    <description><?php echo '<![CDATA[' . largo_excerpt( $post, 5, false, '', false ) . ']]>';  ?></description>
+    <pubDate><?php rss_date( strtotime( $post->post_date_gmt ) ); ?></pubDate>
+    <guid><?php the_permalink(); ?></guid>
+    <source><?php echo get_post_meta( $post->ID, 'lr_source', true ); ?></source>
+    <dc:creator><?php $curuser = get_user_by( 'id', $post->post_author ); echo $curuser->first_name . ' ' . $curuser->last_name; ?></dc:creator>
+	<?php if( get_the_post_thumbnail( $post->ID ) ): $image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ) ); ?>
+    <media:content url="<?php echo esc_url( $image[0] ); ?>" medium="image" />
+	<?php endif; ?>
+  </item>
+<?php } // foreach ?>
+</channel>
+</rss>

--- a/wp-content/themes/aspen/feed-daily-roundup.php
+++ b/wp-content/themes/aspen/feed-daily-roundup.php
@@ -18,7 +18,7 @@ function rss_date( $timestamp = null ) {
 
 /**
  * Function to see if we want to grab posts from today after 12:30PM
- * or from yesterday after 12PM until today before 12:30PM
+ * or from yesterday after 12:30PM until today before 12:30PM
  * 
  * @return Arr $query_time An array of arguments to use in the query_posts date_query arg.
  */
@@ -29,7 +29,7 @@ function rss_posts_date_query() {
         $query_time = array(
             array(
                 'before' => date( 'm/d/Y 12:30:00' ),
-                'after' => date( 'm/d/Y 12:00:00', strtotime( '-1 days' ) ),
+                'after' => date( 'm/d/Y 12:30:00', strtotime( '-1 days' ) ),
                 'inclusive' => false,
             )
         );

--- a/wp-content/themes/aspen/functions.php
+++ b/wp-content/themes/aspen/functions.php
@@ -77,3 +77,18 @@ function aspen_subscribe_button( $location = null ) {
 
     }
 }
+
+/**
+ * Register a custom RSS feed for MailChimp (to include thumbnail images) for daily saved links from Link Roundups
+ * Feed address to use for MailChimp import will be http://myurl.com/?feed=daily-roundup
+ * And then you'll use the *|RSSITEM:IMAGE|* merge tag in your MailChimp template
+ * 
+ * @see https://github.com/INN/largo/blob/512da701664b329f2f92244bbe54880a6e146431/inc/custom-feeds.php#L16-L28
+ */
+function aspen_add_custom_daily_roundup_feed() {
+
+	add_filter('pre_option_rss_use_excerpt', '__return_zero');
+	load_template( get_stylesheet_directory() . '/feed-daily-roundup.php' );
+
+}
+add_feed( 'daily-roundup', 'aspen_add_custom_daily_roundup_feed' );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds a new RSS feed at `?feed=daily-roundup`, based on the Largo Mailchimp feed, with a few modifications:
   - only grabs saved links post type
   - no limit of posts grabbed
  - `<link>` is the saved link
  - `<source>` is the saved link source
   - only shows from x if current time is y:
      - if current time is after 12PM, shows posts from today after 12PM
      - if current time is before 12PM, shows posts from yesterday at 12PM until now

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #6

## Testing/Questions

Features that this PR affects:

- New RSS feed

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] Brent mentioned he likes to have all of his links in by 12PM which is why we settled on 12PM here. However, he's in Mountain time, which is why instead of using `time()` to grab the time it's using `current_time()` instead so it grabs the WP timezone time, which is set to Mountain. Do we need any other timezone considerations here that I missed?

Steps to test this PR:

1. Add some saved links and publish them after 12PM. If you're viewing this after 12PM, make sure they appear on the feed.
2. Add some saved links and publish them yesterday at and before 12PM. If you're viewing this before 12PM, make sure that
   - posts published before 12PM yesterday don't appear
   - posts published after 12PM yesterday do appear