### PR TITLE
Remove daily roundup RSS feed time check conditional, let Mailchimp handle it

### DIFF
--- a/wp-content/themes/aspen/feed-daily-roundup.php
+++ b/wp-content/themes/aspen/feed-daily-roundup.php
@@ -2,57 +2,23 @@
 /**
  * Template Name: Daily Roundup Feed
  * Copied from https://raw.githubusercontent.com/pastpages/Largo/master/feed-mailchimp.php
- * A feed with thumbnail images for MailChimp import that pulls in all saved links from 12PM to the following day 12PM
+ * A feed with thumbnail images for MailChimp import that pulls in all saved links
  * Feed address to use for MailChimp import will be http://myurl.com/?feed=daily-roundup
  *
  * @package Largo
  * @since 0.2
  */
 
-$numposts = -1;
+$numposts = 100;
 
 function rss_date( $timestamp = null ) {
   $timestamp = ($timestamp==null) ? time() : $timestamp;
   echo date(DATE_RSS, $timestamp);
 }
 
-/**
- * Function to see if we want to grab posts from today after 12:30PM
- * or from yesterday after 12:30PM until today before 12:30PM
- * 
- * @return Arr $query_time An array of arguments to use in the query_posts date_query arg.
- */
-function rss_posts_date_query() {
-
-    if( current_time( 'H:m' ) < '12:30' ) {
-
-        $query_time = array(
-            array(
-                'before' => date( 'm/d/Y 12:30:00' ),
-                'after' => date( 'm/d/Y 12:30:00', strtotime( '-1 days' ) ),
-                'inclusive' => false,
-            )
-        );
-
-    } else {
-
-        $query_time = array(
-            array(
-                'after' => date( 'm/d/Y 12:30:00' ),
-                'inclusive' => true,
-            )
-        );
-
-    }
-
-    return $query_time;
-
-}
-
 $posts = query_posts( array(
   'showposts' => $numposts,
   'post_type' => 'rounduplink',
-  'date_query' => rss_posts_date_query(),
 ) );
 
 $lastpost = $numposts - 1;


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes the date query arg and additional time check conditional to only show posts from x to y time in favor of letting Mailchimp handle grabbing relevant posts

In the [docs](https://mailchimp.com/help/troubleshooting-rss-in-campaigns/):

> We pull in the date for any of these tags, in this order: 'pubDate', 'pubdate', 'published', 'created', 'updated', 'date.' If you set your campaign to daily, it will send posts from the last 24 hours before it was triggered;

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #6

## Testing/Questions

Features that this PR affects:

- Daily roundup RSS feed

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. View the daily roundups RSS feed and make sure 100 posts display